### PR TITLE
Execution alarm

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -65,7 +65,7 @@ Parameters:
       - ENABLED
       - DISABLED
   SNSTopicForAlerts:
-    Description: SNS topic for alerts
+    Description: Name of the SNS topic for alerts
     Type: String
 
 Resources:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -64,6 +64,9 @@ Parameters:
     AllowedValues:
       - ENABLED
       - DISABLED
+  SNSTopicForAlerts:
+    Description: SNS topic for alerts
+    Type: String
 
 Resources:
 
@@ -226,3 +229,22 @@ Resources:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
+
+  ExecutionFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
+      AlarmName: !Sub ${App}-failed-${Stage}
+      AlarmDescription: !Sub Ticker calculation failed for stage ${Stage}
+      MetricName: ExecutionsFailed
+      Namespace: AWS/States
+      Dimensions:
+        - Name: StateMachineArn
+          Value: !Ref StateMachine
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+


### PR DESCRIPTION
will trigger an alert if the state machine fails (which means we're unable to update the ticker value)