### PR TITLE
Currency filter

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -40,8 +40,11 @@ Parameters:
   GoalAmount:
     Description: The campaign goal amount
     Type: Number
-  CountryCodes:
-    Description: Comma-separated, quoted list of country codes, e.g. 'US,AU'. Note - cannot use CommaDelimitedList type if passing into environment variables
+  CountryCode:
+    Description: Country code to filter by
+    Type: String
+  Currency:
+    Description: Currency to filter by
     Type: String
   TickerBucket:
     Description: Bucket to output the result to
@@ -84,7 +87,8 @@ Resources:
           Stage: !Ref Stage
           AthenaOutputBucket: !Ref AthenaOutputBucket
           SchemaName: !Ref SchemaName
-          CountryCodes: !Ref CountryCodes
+          CountryCode: !Ref CountryCode
+          Currency: !Ref Currency
           StartDate: !Ref StartDate
           EndDate: !Ref EndDate
       CodeUri:

--- a/src/query-lambda/queries.ts
+++ b/src/query-lambda/queries.ts
@@ -12,37 +12,41 @@ export class Query {
 
 const formatDateTime = (dt: Moment) => dt.format('YYYY-MM-DD ')
 
-const fullQuery = (startDate: Moment, countryCodesString: string, tableName: string) => new Query(
+const fullQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
-        `WHERE country_code in (${countryCodesString}) ` +
+        `WHERE country_code = ${countryCode} ` +
+        `AND currency = ${currency} ` +
         `AND timestamp > CAST('${startDate.format('YYYY-MM-DD')}' AS TIMESTAMP) `,
     'acquisition_events_full'
 );
 
-const oneOffAndAnnuallyQuery = (startDate: Moment, countryCodesString: string, tableName: string) => new Query(
+const oneOffAndAnnuallyQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
-        `WHERE country_code in (${countryCodesString}) ` +
+        `WHERE country_code = ${countryCode} ` +
+        `AND currency = ${currency} ` +
         `AND timestamp > CAST('${startDate.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
         `AND payment_frequency IN ('OneOff', 'Annually')`,
     'acquisition_events_oneOffAndAnnually'
 );
 
-const firstMonthlyQuery = (startDate: Moment, oneMonthBeforeEnd: Moment, countryCodesString: string, tableName: string) => new Query(
+const firstMonthlyQuery = (startDate: Moment, oneMonthBeforeEnd: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount)*2 ' +
         `FROM ${tableName} ` +
-        `WHERE country_code in (${countryCodesString}) ` +
+        `WHERE country_code = ${countryCode} ` +
+        `AND currency = ${currency} ` +
         `AND timestamp > CAST('${startDate.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
         `AND timestamp < CAST('${oneMonthBeforeEnd.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
         `AND payment_frequency='Monthly'`,
     'acquisition_events_firstMonthlyQuery'
 );
 
-const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryCodesString: string, tableName: string) => new Query(
+const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
-        `WHERE country_code in (${countryCodesString}) ` +
+        `WHERE country_code = ${countryCode} ` +
+        `AND currency = ${currency} ` +
         `AND timestamp >= CAST('${oneMonthBeforeEnd.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
         `AND payment_frequency='Monthly'`,
     'acquisition_events_secondMonthlyQuery'
@@ -52,14 +56,14 @@ const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryC
  * If a campaign runs for more than a month then double any monthly contributions received before the final month.
  * This logic assumes campaigns will not run for more than 2 months.
  */
-export function getQueries(startDate: Moment, endDate: Moment, countryCodesString: string, stage: string): Query[] {
+export function getQueries(startDate: Moment, endDate: Moment, countryCode: string, currency: string, stage: string): Query[] {
     const oneMonthBeforeEnd = endDate.clone().subtract(1, 'month');
     const tableName = `acquisition_events_${stage.toLowerCase()}`;
 
     if (oneMonthBeforeEnd.isAfter(startDate)) return [
-        oneOffAndAnnuallyQuery(startDate, countryCodesString, tableName),
-        firstMonthlyQuery(startDate, oneMonthBeforeEnd, countryCodesString, tableName),
-        secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCodesString, tableName)
+        oneOffAndAnnuallyQuery(startDate, countryCode, currency, tableName),
+        firstMonthlyQuery(startDate, oneMonthBeforeEnd, countryCode, currency, tableName),
+        secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCode, currency, tableName)
     ];
-    else return [fullQuery(startDate, countryCodesString, tableName)];
+    else return [fullQuery(startDate, countryCode, currency, tableName)];
 }

--- a/src/query-lambda/queries.ts
+++ b/src/query-lambda/queries.ts
@@ -10,14 +10,14 @@ export class Query {
     }
 }
 
-const formatDateTime = (dt: Moment) => dt.format('YYYY-MM-DD ')
+const formatDateTime = (dt: Moment) => dt.format('YYYY-MM-DD');
 
 const fullQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
         `WHERE country_code = ${countryCode} ` +
         `AND currency = ${currency} ` +
-        `AND timestamp > CAST('${startDate.format('YYYY-MM-DD')}' AS TIMESTAMP) `,
+        `AND timestamp > CAST('${formatDateTime(startDate)}' AS TIMESTAMP) `,
     'acquisition_events_full'
 );
 
@@ -26,7 +26,7 @@ const oneOffAndAnnuallyQuery = (startDate: Moment, countryCode: string, currency
         `FROM ${tableName} ` +
         `WHERE country_code = ${countryCode} ` +
         `AND currency = ${currency} ` +
-        `AND timestamp > CAST('${startDate.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
+        `AND timestamp > CAST('${formatDateTime(startDate)}' AS TIMESTAMP) ` +
         `AND payment_frequency IN ('OneOff', 'Annually')`,
     'acquisition_events_oneOffAndAnnually'
 );
@@ -36,8 +36,8 @@ const firstMonthlyQuery = (startDate: Moment, oneMonthBeforeEnd: Moment, country
         `FROM ${tableName} ` +
         `WHERE country_code = ${countryCode} ` +
         `AND currency = ${currency} ` +
-        `AND timestamp > CAST('${startDate.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
-        `AND timestamp < CAST('${oneMonthBeforeEnd.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
+        `AND timestamp > CAST('${formatDateTime(startDate)}' AS TIMESTAMP) ` +
+        `AND timestamp < CAST('${formatDateTime(oneMonthBeforeEnd)}' AS TIMESTAMP) ` +
         `AND payment_frequency='Monthly'`,
     'acquisition_events_firstMonthlyQuery'
 );
@@ -47,7 +47,7 @@ const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryC
         `FROM ${tableName} ` +
         `WHERE country_code = ${countryCode} ` +
         `AND currency = ${currency} ` +
-        `AND timestamp >= CAST('${oneMonthBeforeEnd.format('YYYY-MM-DD')}' AS TIMESTAMP) ` +
+        `AND timestamp >= CAST('${formatDateTime(oneMonthBeforeEnd)}' AS TIMESTAMP) ` +
         `AND payment_frequency='Monthly'`,
     'acquisition_events_secondMonthlyQuery'
 );

--- a/src/query-lambda/queries.ts
+++ b/src/query-lambda/queries.ts
@@ -15,8 +15,8 @@ const formatDateTime = (dt: Moment) => dt.format('YYYY-MM-DD');
 const fullQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
-        `WHERE country_code = ${countryCode} ` +
-        `AND currency = ${currency} ` +
+        `WHERE country_code = '${countryCode}' ` +
+        `AND currency = '${currency}' ` +
         `AND timestamp > CAST('${formatDateTime(startDate)}' AS TIMESTAMP) `,
     'acquisition_events_full'
 );
@@ -24,8 +24,8 @@ const fullQuery = (startDate: Moment, countryCode: string, currency: string, tab
 const oneOffAndAnnuallyQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
-        `WHERE country_code = ${countryCode} ` +
-        `AND currency = ${currency} ` +
+        `WHERE country_code = '${countryCode}' ` +
+        `AND currency = '${currency}' ` +
         `AND timestamp > CAST('${formatDateTime(startDate)}' AS TIMESTAMP) ` +
         `AND payment_frequency IN ('OneOff', 'Annually')`,
     'acquisition_events_oneOffAndAnnually'
@@ -34,8 +34,8 @@ const oneOffAndAnnuallyQuery = (startDate: Moment, countryCode: string, currency
 const firstMonthlyQuery = (startDate: Moment, oneMonthBeforeEnd: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount)*2 ' +
         `FROM ${tableName} ` +
-        `WHERE country_code = ${countryCode} ` +
-        `AND currency = ${currency} ` +
+        `WHERE country_code = '${countryCode}' ` +
+        `AND currency = '${currency}' ` +
         `AND timestamp > CAST('${formatDateTime(startDate)}' AS TIMESTAMP) ` +
         `AND timestamp < CAST('${formatDateTime(oneMonthBeforeEnd)}' AS TIMESTAMP) ` +
         `AND payment_frequency='Monthly'`,
@@ -45,8 +45,8 @@ const firstMonthlyQuery = (startDate: Moment, oneMonthBeforeEnd: Moment, country
 const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryCode: string, currency: string, tableName: string) => new Query(
     'SELECT SUM(amount) ' +
         `FROM ${tableName} ` +
-        `WHERE country_code = ${countryCode} ` +
-        `AND currency = ${currency} ` +
+        `WHERE country_code = '${countryCode}' ` +
+        `AND currency = '${currency}' ` +
         `AND timestamp >= CAST('${formatDateTime(oneMonthBeforeEnd)}' AS TIMESTAMP) ` +
         `AND payment_frequency='Monthly'`,
     'acquisition_events_secondMonthlyQuery'

--- a/src/query-lambda/query-lambda.ts
+++ b/src/query-lambda/query-lambda.ts
@@ -9,8 +9,8 @@ class Config {
     StartDate: string = process.env.StartDate;
     EndDate: string = process.env.EndDate;
 
-    //A quoted, comma-separated list as a string, e.g. 'US','AU'
-    CountryCodesString: string = process.env.CountryCodes;
+    CountryCode: string = process.env.CountryCode;
+    Currency: string = process.env.Currency;
 
     AthenaOutputBucket: string = process.env.AthenaOutputBucket;
 
@@ -29,9 +29,9 @@ export async function handler(): Promise<string[]> {
     const StartDate: Moment = moment(config.StartDate);
     const EndDate: Moment = moment(config.EndDate);
 
-    console.log(`Getting total for period ${config.StartDate}-${config.EndDate} and country codes ${config.CountryCodesString}`);
+    console.log(`Getting total for period ${config.StartDate}-${config.EndDate} with country code ${config.CountryCode} and currency ${config.Currency}`);
 
-    const queries = getQueries(StartDate, EndDate, config.CountryCodesString, config.Stage);
+    const queries = getQueries(StartDate, EndDate, config.CountryCode, config.Currency, config.Stage);
 
     return Promise.all(queries.map(executeQuery))
         .then((results: StartQueryExecutionOutput[]) => results.map(result => result.QueryExecutionId))


### PR DESCRIPTION
1. Filter by currency
2. Allow only one country code (as this is all we're likely to need)
3. Also, use the `formatDateTime` helper that I forgot to use previously.

e.g. `SELECT SUM(amount) FROM acquisition_events_code WHERE country_code = 'US' AND currency = 'USD' AND timestamp > CAST('2018-12-19' AS TIMESTAMP)`