### PR TITLE
Increase retry interval

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -197,7 +197,7 @@ Resources:
                   "End": true,
                   "Retry": [{
                     "ErrorEquals": ["QueryPendingError"],
-                    "IntervalSeconds": 5,
+                    "IntervalSeconds": 10,
                     "MaxAttempts": 5
                   }]
                 }


### PR DESCRIPTION
The 'calculate' lambda polls the status of the athena query until the result is ready, or it has tried 5 times.
Sometimes it exceeds the limit, so I'm increasing the interval between polls.

Weirdly, the athena history page reports the query as taking ~3 seconds, but the query result is sometimes not available after 3 mins