### PR TITLE
Increase failure alarm threshold to 2 in a row

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -248,15 +248,15 @@ Resources:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
       AlarmName: !Sub ${App}-failed-${Stage}
-      AlarmDescription: !Sub Ticker calculation failed for stage ${Stage}
+      AlarmDescription: !Sub Ticker calculation failed twice in 30mins for stage ${Stage}
       MetricName: ExecutionsFailed
       Namespace: AWS/States
       Dimensions:
         - Name: StateMachineArn
           Value: !Ref StateMachine
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 1
-      Period: 60
-      EvaluationPeriods: 1
+      Threshold: 2
+      Period: 900
+      EvaluationPeriods: 2
       Statistic: Sum
 


### PR DESCRIPTION
the state machine sometimes times out polling the result of the athena query. This is weird and I think it's a problem in AWS but don't have time to investigate now and it's not urgent.
For now, only trigger the alarm if 2 runs fail in a row.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html
Period is 900 (seconds) because the state machine runs every 15 mins.
EvaluationPeriods is 2 because I want to alarm only if it fails on 2 consecutive runs.
Threshold is 2 because I want to alarm if both runs have failed.