### PR TITLE
Fix frequency names in query

### DIFF
--- a/src/value-ticker/query-lambda/queries.ts
+++ b/src/value-ticker/query-lambda/queries.ts
@@ -23,7 +23,7 @@ const oneOffAndAnnuallyQuery = (startDate: Moment, countryCode: string, currency
         `AND currency = '${currency}' ` +
         (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
         `AND ${partitionDateField} >= date'${formatDateTime(startDate)}' ` +
-        `AND paymentFrequency IN ('OneOff', 'Annually')`,
+        `AND paymentFrequency IN ('ONE_OFF', 'ANNUALLY')`,
     'acquisition_events_oneOffAndAnnually'
 );
 
@@ -35,7 +35,7 @@ const firstMonthlyQuery = (startDate: Moment, oneMonthBeforeEnd: Moment, country
         (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
         `AND ${partitionDateField} >= date'${formatDateTime(startDate)}' ` +
         `AND ${partitionDateField} < date'${formatDateTime(oneMonthBeforeEnd)}' ` +
-        `AND paymentFrequency='Monthly'`,
+        `AND paymentFrequency='MONTHLY'`,
     'acquisition_events_firstMonthlyQuery'
 );
 
@@ -46,7 +46,7 @@ const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryC
         `AND currency = '${currency}' ` +
         (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
         `AND ${partitionDateField} >= date'${formatDateTime(oneMonthBeforeEnd)}' ` +
-        `AND paymentFrequency='Monthly'`,
+        `AND paymentFrequency='MONTHLY'`,
     'acquisition_events_secondMonthlyQuery'
 );
 


### PR DESCRIPTION
The formatting of the frequencyName field has changed since we migrated away from thrift.
This is what we now have in athena:
![Screen Shot 2021-11-22 at 13 20 00](https://user-images.githubusercontent.com/1513454/142869603-2ce11a11-c372-4697-a147-747d3b5ba9d9.png)
