### PR TITLE
Make filename configurable

### DIFF
--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -15,6 +15,7 @@ class Config {
     GoalAmount: number = parseInt(process.env.GoalAmount);
 
     TickerBucket: string = process.env.TickerBucket;
+    OutputFilename: string = process.env.OutputFilename
 }
 
 const config = new Config();
@@ -24,7 +25,7 @@ export async function handler(executionIds: QueryExecutionId[]): Promise<Managed
         executionIds,
         reduce,
         config.TickerBucket,
-        `${config.Stage}/ticker.json`,
+        `${config.Stage}/${config.OutputFilename}`,
         athena
     );
 }

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -59,6 +59,9 @@ Parameters:
   EndDate:
     Description: The end of the campaign, e.g. 2018-02-01
     Type: String
+  OutputFilename:
+    Description: The name of the file to output the results to in S3
+    Type: String
   CronExpression:
     Description: Cron expression for scheduling the step functions
     Type: String
@@ -98,6 +101,7 @@ Resources:
           Currency: !Ref Currency
           StartDate: !Ref StartDate
           EndDate: !Ref EndDate
+          OutputFilename: !Ref OutputFilename
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip


### PR DESCRIPTION
We need to run 2 tickers concurrently.
For simplicity (we have a tight deadline) we're just going to spin up a new stack and output to a different file in S3.
With this PR, the filename is set from a cloudformation parameter.