### PR TITLE
Separate riff-raff deploys

### DIFF
--- a/src/value-ticker/riff-raff-au.yaml
+++ b/src/value-ticker/riff-raff-au.yaml
@@ -2,12 +2,12 @@ stacks: [support]
 regions: [eu-west-1]
 
 deployments:
-  contributions-ticker-calculator:
+  contributions-ticker-calculator-au:
     type: aws-lambda
     parameters:
       prefixStack: false
       bucket: membership-dist
       fileName: contributions-ticker-calculator.zip
       functionNames:
-        - contributions-ticker-query-lambda-
-        - contributions-ticker-calculate-lambda-
+        - contributions-ticker-query-lambda-au-
+        - contributions-ticker-calculate-lambda-au-

--- a/src/value-ticker/riff-raff-us.yaml
+++ b/src/value-ticker/riff-raff-us.yaml
@@ -1,0 +1,13 @@
+stacks: [support]
+regions: [eu-west-1]
+
+deployments:
+  contributions-ticker-calculator-us:
+    type: aws-lambda
+    parameters:
+      prefixStack: false
+      bucket: membership-dist
+      fileName: contributions-ticker-calculator.zip
+      functionNames:
+        - contributions-ticker-query-lambda-us-
+        - contributions-ticker-calculate-lambda-us-

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -13,7 +13,7 @@ yarn run build
 
 # These also need to be in the RiffRaff package
 cp package.json target
-cp riff-raff.yaml target
+cp riff-raff-$1.yaml target
 
 pushd target
 # Ensures the RiffRaff package has the node_modules needed to run


### PR DESCRIPTION
Now that we have stacks for US and AU, we also need separate riffraff deploys. Otherwise riffraff doesn't know which lambdas to update during the deploy.

This is a bit of a hack, maybe one day we can make it possible to configure a single stack to do multple campaigns...