### PR TITLE
Config to support two campaigns

### DIFF
--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -1,0 +1,25 @@
+const AWS = require('aws-sdk');
+import { GetObjectOutput } from 'aws-sdk/clients/s3';
+
+const S3 = new AWS.S3();
+
+export const getConfig = (stage: string) => {
+    const Bucket = 'membership-private';
+    const Key = `${stage}/ticker.conf.json`;
+
+    return S3.getObject({
+        Bucket,
+        Key,
+    })
+        .promise()
+        .then((result: GetObjectOutput) => {
+            if (result.Body) {
+                return Promise.resolve(result.Body.toString('utf-8'));
+            } else {
+                return Promise.reject(
+                    new Error(`Missing Body in S3 response for ${Bucket}/${Key}`),
+                );
+            }
+        })
+        .catch(err => Promise.reject(`Failed to fetch S3 object ${Bucket}/${Key}: ${err}`));
+}

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -14,7 +14,7 @@ export const getConfig = (stage: string) => {
         .promise()
         .then((result: GetObjectOutput) => {
             if (result.Body) {
-                return Promise.resolve<string>(result.Body.toString('utf-8') as string);
+                return result.Body.toString('utf-8');
             } else {
                 return Promise.reject(
                     new Error(`Missing Body in S3 response for ${Bucket}/${Key}`),

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -14,7 +14,7 @@ export const getConfig = (stage: string) => {
         .promise()
         .then((result: GetObjectOutput) => {
             if (result.Body) {
-                return Promise.resolve(result.Body.toString('utf-8'));
+                return Promise.resolve(result.Body.toString('utf-8') as string);
             } else {
                 return Promise.reject(
                     new Error(`Missing Body in S3 response for ${Bucket}/${Key}`),

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -14,7 +14,7 @@ export const getConfig = (stage: string) => {
         .promise()
         .then((result: GetObjectOutput) => {
             if (result.Body) {
-                return Promise.resolve(result.Body.toString('utf-8') as string);
+                return Promise.resolve<string>(result.Body.toString('utf-8') as string);
             } else {
                 return Promise.reject(
                     new Error(`Missing Body in S3 response for ${Bucket}/${Key}`),

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -14,7 +14,7 @@ export const getConfig = (stage: string) => {
         .promise()
         .then((result: GetObjectOutput) => {
             if (result.Body) {
-                return result.Body.toString('utf-8');
+                return result.Body.toString();
             } else {
                 return Promise.reject(
                     new Error(`Missing Body in S3 response for ${Bucket}/${Key}`),

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -14,7 +14,7 @@ export const getConfig = (stage: string) => {
         .promise()
         .then((result: GetObjectOutput) => {
             if (result.Body) {
-                return result.Body.toString();
+                return JSON.parse(result.Body.toString());
             } else {
                 return Promise.reject(
                     new Error(`Missing Body in S3 response for ${Bucket}/${Key}`),

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -21,7 +21,7 @@ class Config {
 const config = new Config();
 
 export async function handler(executionIds: QueryExecutionId[]): Promise<ManagedUpload.SendData> {
-    console.log(config);
+    console.log(executionIds);
     return reduceAndWrite(
         executionIds,
         reduce,

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -25,9 +25,9 @@ interface Event {
 }
 
 export async function handler(event: Event): Promise<ManagedUpload.SendData> {
-    console.log({event})
+    console.log({event});
     const config: Config = (await getConfig(stage))[event.Name];
-    console.log({config})
+
     return reduceAndWrite(
         event.ExecutionIds,
         reduce(config),

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -12,12 +12,11 @@ const athena = new AWS.Athena({region: 'eu-west-1'});
 class Config {
     InitialAmount: number;
     GoalAmount: number;
-
-    TickerBucket: string;
     OutputFilename: string;
 }
 
 const stage = process.env.Stage;
+const tickerBucket = process.env.TickerBucket
 
 export interface CalculateLambdaEvent {
     ExecutionIds: QueryExecutionId[];
@@ -31,7 +30,7 @@ export async function handler(event: CalculateLambdaEvent): Promise<ManagedUploa
     return reduceAndWrite(
         event.ExecutionIds,
         reduce(config),
-        config.TickerBucket,
+        tickerBucket,
         `${stage}/${config.OutputFilename}`,
         athena
     );

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -19,12 +19,17 @@ class Config {
 
 const stage = process.env.Stage;
 
-export async function handler(executionIds: QueryExecutionId[]): Promise<ManagedUpload.SendData> {
-    console.log({executionIds})
+interface Event {
+    executionIds: QueryExecutionId[];
+    Name: string;
+}
+
+export async function handler(event: Event): Promise<ManagedUpload.SendData> {
+    console.log({event})
     const config: Config = await getConfig(stage);
     console.log({config})
     return reduceAndWrite(
-        executionIds,
+        event.executionIds,
         reduce(config),
         config.TickerBucket,
         `${stage}/${config.OutputFilename}`,

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -19,12 +19,12 @@ class Config {
 
 const stage = process.env.Stage;
 
-interface Event {
+export interface CalculateLambdaEvent {
     ExecutionIds: QueryExecutionId[];
     Name: string;
 }
 
-export async function handler(event: Event): Promise<ManagedUpload.SendData> {
+export async function handler(event: CalculateLambdaEvent): Promise<ManagedUpload.SendData> {
     console.log({event});
     const config: Config = (await getConfig(stage))[event.Name];
 

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -20,16 +20,16 @@ class Config {
 const stage = process.env.Stage;
 
 interface Event {
-    executionIds: QueryExecutionId[];
+    ExecutionIds: QueryExecutionId[];
     Name: string;
 }
 
 export async function handler(event: Event): Promise<ManagedUpload.SendData> {
     console.log({event})
-    const config: Config = await getConfig(stage);
+    const config: Config = (await getConfig(stage))[event.Name];
     console.log({config})
     return reduceAndWrite(
-        event.executionIds,
+        event.ExecutionIds,
         reduce(config),
         config.TickerBucket,
         `${stage}/${config.OutputFilename}`,

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -20,7 +20,9 @@ class Config {
 const stage = process.env.Stage;
 
 export async function handler(executionIds: QueryExecutionId[]): Promise<ManagedUpload.SendData> {
+    console.log({executionIds})
     const config: Config = await getConfig(stage);
+    console.log({config})
     return reduceAndWrite(
         executionIds,
         reduce(config),

--- a/src/value-ticker/calculate-lambda/calculate-lambda.ts
+++ b/src/value-ticker/calculate-lambda/calculate-lambda.ts
@@ -12,7 +12,6 @@ const athena = new AWS.Athena({region: 'eu-west-1'});
 class Config {
     InitialAmount: number;
     GoalAmount: number;
-    OutputFilename: string;
 }
 
 const stage = process.env.Stage;
@@ -31,7 +30,7 @@ export async function handler(event: CalculateLambdaEvent): Promise<ManagedUploa
         event.ExecutionIds,
         reduce(config),
         tickerBucket,
-        `${stage}/${config.OutputFilename}`,
+        `${stage}/${event.Name}.json`,
         athena
     );
 }

--- a/src/value-ticker/calculate-lambda/local.ts
+++ b/src/value-ticker/calculate-lambda/local.ts
@@ -12,10 +12,10 @@ AWS.config.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
-async function run(ids: string) {
-    await handler(ids.split(','))
-        .then(result => console.log(`Result: ${JSON.stringify(result)}`))
-        .catch(err => console.log(`Error: ${err}`))
-}
-
-run(process.argv[2]);
+// async function run(ids: string) {
+//     await handler(ids.split(','))
+//         .then(result => console.log(`Result: ${JSON.stringify(result)}`))
+//         .catch(err => console.log(`Error: ${err}`))
+// }
+//
+// run(process.argv[2]);

--- a/src/value-ticker/calculate-lambda/local.ts
+++ b/src/value-ticker/calculate-lambda/local.ts
@@ -3,7 +3,7 @@ let AWS = require('aws-sdk');
 
 /**
  * For testing locally:
- * `yarn run calculate-local <execution id>,<execution id>,...`
+ * `yarn run calculate-local <name> <execution id>,<execution id>,...`
  */
 
 AWS.config = new AWS.Config();
@@ -12,10 +12,13 @@ AWS.config.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
-// async function run(ids: string) {
-//     await handler(ids.split(','))
-//         .then(result => console.log(`Result: ${JSON.stringify(result)}`))
-//         .catch(err => console.log(`Error: ${err}`))
-// }
-//
-// run(process.argv[2]);
+async function run(name: string, ids: string) {
+    await handler({
+        Name: name,
+        ExecutionIds: ids.split(','),
+    })
+        .then(result => console.log(`Result: ${JSON.stringify(result)}`))
+        .catch(err => console.log(`Error: ${err}`))
+}
+
+run(process.argv[2], process.argv[3]);

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -205,7 +205,7 @@ Resources:
                 "Query": {
                   "Type": "Task",
                   "Resource": "${QueryLambdaArn}",
-                  "Next": "Calculate"
+                  "Next": "Calculate",
                   "Parameters": {
                     "Name": "US_2022"
                   }

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -194,10 +194,7 @@ Resources:
                 "Query": {
                   "Type": "Task",
                   "Resource": "${QueryLambdaArn}",
-                  "Next": "Calculate",
-                  "Parameters": {
-                    "Name": "US_2022"
-                  }
+                  "Next": "Calculate"
                 },
                 "Calculate": {
                   "Type": "Task",
@@ -207,11 +204,7 @@ Resources:
                     "ErrorEquals": ["QueryPendingError"],
                     "IntervalSeconds": 10,
                     "MaxAttempts": 5
-                  }],
-                  "Parameters": {
-                    "Name": "US_2022",
-                    "ExecutionIds.$": "$"
-                  }
+                  }]
                 }
               }
             }
@@ -253,16 +246,7 @@ Resources:
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
           Input:
-            !Sub '{
-              "Stage": "${Stage}",
-              "AthenaOutputBucket": "${AthenaOutputBucket}",
-              "SchemaName": "${SchemaName}",
-              "CountryCode": "${CountryCode}",
-              "CampaignCode": "${CampaignCode}",
-              "Currency": "${Currency}",
-              "StartDate": "${StartDate}",
-              "EndDate": "${EndDate}"
-            }'
+            !Sub '{ "Name": "US_2022" }'
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -218,8 +218,7 @@ Resources:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
-          Input:
-            !Sub '{ "Name": "US_2022" }'
+          Input: '{ "Name": "US_2022" }'
   ScheduleAU:
     Type: AWS::Events::Rule
     Properties:
@@ -230,8 +229,7 @@ Resources:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
-          Input:
-            !Sub '{ "Name": "AU_2022" }'
+          Input: '{ "Name": "AU_2022" }'
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -126,6 +126,7 @@ Resources:
             Action: s3:GetObject
             Resource:
               - arn:aws:s3::*:membership-dist/*
+              - arn:aws:s3::*:membership-private/${Stage}/ticker.conf.json
 
   CalculateLambda:
     Type: AWS::Serverless::Function
@@ -163,6 +164,7 @@ Resources:
             Action: s3:GetObject
             Resource:
               - arn:aws:s3::*:membership-dist/*
+              - arn:aws:s3::*:membership-private/${Stage}/ticker.conf.json
 
   StateMachineExecutionRole:
     Type: "AWS::IAM::Role"
@@ -203,17 +205,7 @@ Resources:
                 "Query": {
                   "Type": "Task",
                   "Resource": "${QueryLambdaArn}",
-                  "Next": "Calculate",
-                  "Parameters": {
-                    "Stage": "${Stage}",
-                    "AthenaOutputBucket": "${AthenaOutputBucket}",
-                    "SchemaName": "${SchemaName}",
-                    "CountryCode": "${CountryCode}",
-                    "CampaignCode": "${CampaignCode}",
-                    "Currency": "${Currency}",
-                    "StartDate": "${StartDate}",
-                    "EndDate": "${EndDate}"
-                  }
+                  "Next": "Calculate"
                 },
                 "Calculate": {
                   "Type": "Task",
@@ -224,13 +216,6 @@ Resources:
                     "IntervalSeconds": 10,
                     "MaxAttempts": 5
                   }]
-                  "Parameters": {
-                    "Stage": "${Stage}",
-                    "InitialAmount": "${InitialAmount}",
-                    "GoalAmount": "${GoalAmount}",
-                    "TickerBucket": "${TickerBucket}",
-                    "OutputFilename": "${OutputFilename}"
-                  }
                 }
               }
             }
@@ -271,6 +256,16 @@ Resources:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
+          Input: !Sub
+            - |
+              "Stage": "${Stage}",
+              "AthenaOutputBucket": "${AthenaOutputBucket}",
+              "SchemaName": "${SchemaName}",
+              "CountryCode": "${CountryCode}",
+              "CampaignCode": "${CampaignCode}",
+              "Currency": "${Currency}",
+              "StartDate": "${StartDate}",
+              "EndDate": "${EndDate}"
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -203,8 +203,10 @@ Resources:
                 "Query": {
                   "Type": "Task",
                   "Resource": "${QueryLambdaArn}",
-                  "Next": "Calculate"
-                  "Parameters": "{ \"name\": \"US_2022\" }"
+                  "Next": "Calculate",
+                  "Parameters": {
+                    "name": "US_2022"
+                  }
                 },
                 "Calculate": {
                   "Type": "Task",

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -91,16 +91,16 @@ Resources:
       Handler: value-ticker/query-lambda/query-lambda.handler
       MemorySize: 128
       Timeout: 300
-      Environment:
-        Variables:
-          Stage: !Ref Stage
-          AthenaOutputBucket: !Ref AthenaOutputBucket
-          SchemaName: !Ref SchemaName
-          CountryCode: !Ref CountryCode
-          CampaignCode: !Ref CampaignCode
-          Currency: !Ref Currency
-          StartDate: !Ref StartDate
-          EndDate: !Ref EndDate
+#      Environment:
+#        Variables:
+#          Stage: !Ref Stage
+#          AthenaOutputBucket: !Ref AthenaOutputBucket
+#          SchemaName: !Ref SchemaName
+#          CountryCode: !Ref CountryCode
+#          CampaignCode: !Ref CampaignCode
+#          Currency: !Ref Currency
+#          StartDate: !Ref StartDate
+#          EndDate: !Ref EndDate
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
@@ -136,13 +136,13 @@ Resources:
       Handler: value-ticker/calculate-lambda/calculate-lambda.handler
       MemorySize: 128
       Timeout: 300
-      Environment:
-        Variables:
-          Stage: !Ref Stage
-          InitialAmount: !Ref InitialAmount
-          GoalAmount: !Ref GoalAmount
-          TickerBucket: !Ref TickerBucket
-          OutputFilename: !Ref OutputFilename
+#      Environment:
+#        Variables:
+#          Stage: !Ref Stage
+#          InitialAmount: !Ref InitialAmount
+#          GoalAmount: !Ref GoalAmount
+#          TickerBucket: !Ref TickerBucket
+#          OutputFilename: !Ref OutputFilename
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
@@ -205,7 +205,14 @@ Resources:
                   "Resource": "${QueryLambdaArn}",
                   "Next": "Calculate",
                   "Parameters": {
-                    "name": "US_2022"
+                    "Stage": "${Stage}",
+                    "AthenaOutputBucket": "${AthenaOutputBucket}",
+                    "SchemaName": "${SchemaName}",
+                    "CountryCode": "${CountryCode}",
+                    "CampaignCode": "${CampaignCode}",
+                    "Currency": "${Currency}",
+                    "StartDate": "${StartDate}",
+                    "EndDate": "${EndDate}"
                   }
                 },
                 "Calculate": {
@@ -217,6 +224,13 @@ Resources:
                     "IntervalSeconds": 10,
                     "MaxAttempts": 5
                   }]
+                  "Parameters": {
+                    "Stage": "${Stage}",
+                    "InitialAmount": "${InitialAmount}",
+                    "GoalAmount": "${GoalAmount}",
+                    "TickerBucket": "${TickerBucket}",
+                    "OutputFilename": "${OutputFilename}"
+                  }
                 }
               }
             }

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -29,39 +29,10 @@ Parameters:
     Description: Name of the bucket to output athena query results to
     Type: String
     Default: acquisition-events-output
-  SchemaName:
-    Description: The schema name for the query
-    Type: String
-    Default: acquisition
-  InitialAmount:
-    Description: Amount to add to the result of the query
-    Type: Number
-    Default: 0
-  GoalAmount:
-    Description: The campaign goal amount
-    Type: Number
-  CountryCode:
-    Description: Country code to filter by
-    Type: String
-  Currency:
-    Description: Currency to filter by
-    Type: String
-  CampaignCode:
-    Description: Campaign code to filter on
-    Type: String
   TickerBucket:
     Description: Bucket to output the result to
     Type: String
     Default: contributions-ticker
-  StartDate:
-    Description: The start of the campaign, e.g. 2018-01-01
-    Type: String
-  EndDate:
-    Description: The end of the campaign, e.g. 2018-02-01
-    Type: String
-  OutputFilename:
-    Description: The name of the file to output the results to in S3
-    Type: String
   CronExpression:
     Description: Cron expression for scheduling the step functions
     Type: String
@@ -94,6 +65,7 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
+          AthenaOutputBucket: !Ref AthenaOutputBucket
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
@@ -133,6 +105,7 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
+          TickerBucket: !Ref TickerBucket
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
@@ -235,10 +208,10 @@ Resources:
             - states:StartExecution
             Resource: !Ref StateMachine
 
-  Schedule:
+  ScheduleUS:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub contributions-ticker-calculator-schedule-${Stage}
+      Name: !Sub contributions-ticker-calculator-schedule-US_2022-${Stage}
       ScheduleExpression: !Sub cron(${CronExpression})
       State: !Ref ScheduleState
       Targets:
@@ -247,6 +220,18 @@ Resources:
           Id: !GetAtt StateMachine.Name
           Input:
             !Sub '{ "Name": "US_2022" }'
+  ScheduleAU:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub contributions-ticker-calculator-schedule-AU_2022-${Stage}
+      ScheduleExpression: !Sub cron(${CronExpression})
+      State: !Ref ScheduleState
+      Targets:
+        - Arn: !Ref StateMachine
+          RoleArn: !GetAtt TriggerExecutionRole.Arn
+          Id: !GetAtt StateMachine.Name
+          Input:
+            !Sub '{ "Name": "AU_2022" }'
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -85,7 +85,7 @@ Resources:
   QueryLambda:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub contributions-ticker-query-lambda-${CountryCode}-${Stage}
+      FunctionName: !Sub contributions-ticker-query-lambda-${Stage}
       Description: Queries Athena for total amounts contributed during a campaign
       Runtime: nodejs12.x
       Handler: value-ticker/query-lambda/query-lambda.handler
@@ -130,7 +130,7 @@ Resources:
   CalculateLambda:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub contributions-ticker-calculate-lambda-${CountryCode}-${Stage}
+      FunctionName: !Sub contributions-ticker-calculate-lambda-${Stage}
       Description: Gets the results of the Athena queries and updates the public ticker file
       Runtime: nodejs12.x
       Handler: value-ticker/calculate-lambda/calculate-lambda.handler
@@ -192,7 +192,7 @@ Resources:
       - CalculateLambda
     Properties:
       StateMachineName:
-        !Sub ${App}-${CountryCode}-${Stage}
+        !Sub ${App}-${Stage}
       DefinitionString:
         !Sub
           - |
@@ -204,6 +204,7 @@ Resources:
                   "Type": "Task",
                   "Resource": "${QueryLambdaArn}",
                   "Next": "Calculate"
+                  "Parameters": "{ \"name\": \"US_2022\" }"
                 },
                 "Calculate": {
                   "Type": "Task",
@@ -247,7 +248,7 @@ Resources:
   Schedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub contributions-ticker-calculator-schedule-${CountryCode}-${Stage}
+      Name: !Sub contributions-ticker-calculator-schedule-${Stage}
       ScheduleExpression: !Sub cron(${CronExpression})
       State: !Ref ScheduleState
       Targets:
@@ -261,7 +262,7 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
-      AlarmName: !Sub ${App}-${CountryCode}-failed-${Stage}
+      AlarmName: !Sub ${App}-failed-${Stage}
       AlarmDescription: !Sub Ticker calculation failed twice in 30mins for stage ${Stage}
       MetricName: ExecutionsFailed
       Namespace: AWS/States

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -206,6 +206,9 @@ Resources:
                   "Type": "Task",
                   "Resource": "${QueryLambdaArn}",
                   "Next": "Calculate"
+                  "Parameters": {
+                    "Name": "US_2022"
+                  }
                 },
                 "Calculate": {
                   "Type": "Task",
@@ -215,7 +218,10 @@ Resources:
                     "ErrorEquals": ["QueryPendingError"],
                     "IntervalSeconds": 10,
                     "MaxAttempts": 5
-                  }]
+                  }],
+                  "Parameters": {
+                    "Name": "US_2022"
+                  }
                 }
               }
             }

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -208,7 +208,8 @@ Resources:
                   "Next": "Calculate",
                   "Parameters": {
                     "Name": "US_2022"
-                  }
+                  },
+                  "ResultPath": "$.executionIds"
                 },
                 "Calculate": {
                   "Type": "Task",

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -94,13 +94,6 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-#          AthenaOutputBucket: !Ref AthenaOutputBucket
-#          SchemaName: !Ref SchemaName
-#          CountryCode: !Ref CountryCode
-#          CampaignCode: !Ref CampaignCode
-#          Currency: !Ref Currency
-#          StartDate: !Ref StartDate
-#          EndDate: !Ref EndDate
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
@@ -140,10 +133,6 @@ Resources:
       Environment:
         Variables:
           Stage: !Ref Stage
-#          InitialAmount: !Ref InitialAmount
-#          GoalAmount: !Ref GoalAmount
-#          TickerBucket: !Ref TickerBucket
-#          OutputFilename: !Ref OutputFilename
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -208,8 +208,7 @@ Resources:
                   "Next": "Calculate",
                   "Parameters": {
                     "Name": "US_2022"
-                  },
-                  "OutputPath": "$.executionIds"
+                  }
                 },
                 "Calculate": {
                   "Type": "Task",

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -256,8 +256,8 @@ Resources:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
-          Input: !Sub
-            - |
+          Input:
+            !Sub '{
               "Stage": "${Stage}",
               "AthenaOutputBucket": "${AthenaOutputBucket}",
               "SchemaName": "${SchemaName}",
@@ -266,6 +266,7 @@ Resources:
               "Currency": "${Currency}",
               "StartDate": "${StartDate}",
               "EndDate": "${EndDate}"
+            }'
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -91,9 +91,9 @@ Resources:
       Handler: value-ticker/query-lambda/query-lambda.handler
       MemorySize: 128
       Timeout: 300
-#      Environment:
-#        Variables:
-#          Stage: !Ref Stage
+      Environment:
+        Variables:
+          Stage: !Ref Stage
 #          AthenaOutputBucket: !Ref AthenaOutputBucket
 #          SchemaName: !Ref SchemaName
 #          CountryCode: !Ref CountryCode
@@ -126,7 +126,7 @@ Resources:
             Action: s3:GetObject
             Resource:
               - arn:aws:s3::*:membership-dist/*
-              - arn:aws:s3::*:membership-private/${Stage}/ticker.conf.json
+              - !Sub arn:aws:s3::*:membership-private/${Stage}/ticker.conf.json
 
   CalculateLambda:
     Type: AWS::Serverless::Function
@@ -137,9 +137,9 @@ Resources:
       Handler: value-ticker/calculate-lambda/calculate-lambda.handler
       MemorySize: 128
       Timeout: 300
-#      Environment:
-#        Variables:
-#          Stage: !Ref Stage
+      Environment:
+        Variables:
+          Stage: !Ref Stage
 #          InitialAmount: !Ref InitialAmount
 #          GoalAmount: !Ref GoalAmount
 #          TickerBucket: !Ref TickerBucket

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -164,7 +164,7 @@ Resources:
             Action: s3:GetObject
             Resource:
               - arn:aws:s3::*:membership-dist/*
-              - arn:aws:s3::*:membership-private/${Stage}/ticker.conf.json
+              - !Sub arn:aws:s3::*:membership-private/${Stage}/ticker.conf.json
 
   StateMachineExecutionRole:
     Type: "AWS::IAM::Role"

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -209,7 +209,7 @@ Resources:
                   "Parameters": {
                     "Name": "US_2022"
                   },
-                  "ResultPath": "$.executionIds"
+                  "OutputPath": "$.executionIds"
                 },
                 "Calculate": {
                   "Type": "Task",
@@ -221,7 +221,8 @@ Resources:
                     "MaxAttempts": 5
                   }],
                   "Parameters": {
-                    "Name": "US_2022"
+                    "Name": "US_2022",
+                    "ExecutionIds.$": "$"
                   }
                 }
               }

--- a/src/value-ticker/package.json
+++ b/src/value-ticker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contributions-ticker-calculator",
   "isAwsLambda": true,
-  "cloudformation": false,
+  "cloudformation": "../cloudformation.yaml",
   "projectName": "Contributions::contributions-ticker-calculator",
   "buildDir": "./target",
   "riffraffFile": "./riff-raff.yaml",

--- a/src/value-ticker/query-lambda/local.ts
+++ b/src/value-ticker/query-lambda/local.ts
@@ -12,10 +12,10 @@ AWS.config.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
-async function run() {
-    await handler({ name: 'US_2022' })
-        .then(result => console.log(`Result: ${JSON.stringify(result)}`))
-        .catch(err => console.log(`Error: ${err}`))
-}
-
-run();
+// async function run() {
+//     await handler({ name: 'US_2022' })
+//         .then(result => console.log(`Result: ${JSON.stringify(result)}`))
+//         .catch(err => console.log(`Error: ${err}`))
+// }
+//
+// run();

--- a/src/value-ticker/query-lambda/local.ts
+++ b/src/value-ticker/query-lambda/local.ts
@@ -13,7 +13,7 @@ AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
 async function run() {
-    await handler()
+    await handler({ name: 'US_2022' })
         .then(result => console.log(`Result: ${JSON.stringify(result)}`))
         .catch(err => console.log(`Error: ${err}`))
 }

--- a/src/value-ticker/query-lambda/local.ts
+++ b/src/value-ticker/query-lambda/local.ts
@@ -12,10 +12,10 @@ AWS.config.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
-// async function run() {
-//     await handler({ name: 'US_2022' })
-//         .then(result => console.log(`Result: ${JSON.stringify(result)}`))
-//         .catch(err => console.log(`Error: ${err}`))
-// }
-//
-// run();
+async function run() {
+    await handler({ Name: 'US_2022' })
+        .then(result => console.log(`Result: ${JSON.stringify(result)}`))
+        .catch(err => console.log(`Error: ${err}`))
+}
+
+run();

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -24,7 +24,8 @@ class Config {
 
 const config = new Config();
 
-export async function handler(): Promise<QueryExecutionId[]> {
+export async function handler(event): Promise<QueryExecutionId[]> {
+    console.log(event)
 
     const StartDate: Moment = moment(config.StartDate);
     const EndDate: Moment = moment(config.EndDate);

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -11,17 +11,14 @@ const athena = new AWS.Athena({region: 'eu-west-1'});
 class Config {
     StartDate: string;
     EndDate: string;
-
     CountryCode: string;
     Currency: string;
-    CampaignCode: string;
-
-    AthenaOutputBucket: string;
-
-    SchemaName: string;
+    CampaignCode?: string;
 }
 
 const stage = process.env.Stage;
+const athenaOutputBucket = process.env.AthenaOutputBucket;
+const schemaName = 'acquisition';
 
 interface QueryLambdaEvent {
     Name: string;
@@ -38,7 +35,7 @@ export async function handler(event: QueryLambdaEvent): Promise<CalculateLambdaE
 
     const queries = getQueries(StartDate, EndDate, config.CountryCode, config.Currency, stage, config.CampaignCode);
 
-    return executeQueries(queries, config.AthenaOutputBucket, config.SchemaName, athena)
+    return executeQueries(queries, athenaOutputBucket, schemaName, athena)
         .then(executionIds => ({
             ExecutionIds: executionIds,
             Name: event.Name,

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -3,28 +3,28 @@ import moment = require("moment");
 import {Moment} from "moment";
 import {getQueries} from "./queries";
 import {executeQueries} from "../../lib/query";
+import {getConfig} from "../../lib/s3";
 
 const AWS = require('aws-sdk');
 const athena = new AWS.Athena({region: 'eu-west-1'});
 
 class Config {
-    Stage: string = process.env.Stage;
+    StartDate: string;
+    EndDate: string;
 
-    StartDate: string = process.env.StartDate;
-    EndDate: string = process.env.EndDate;
+    CountryCode: string;
+    Currency: string;
+    CampaignCode: string;
 
-    CountryCode: string = process.env.CountryCode;
-    Currency: string = process.env.Currency;
-    CampaignCode: string = process.env.CampaignCode;
+    AthenaOutputBucket: string;
 
-    AthenaOutputBucket: string = process.env.AthenaOutputBucket;
-
-    SchemaName: string = process.env.SchemaName;
+    SchemaName: string;
 }
 
-// const config = new Config();
+const stage = process.env.Stage;
 
-export async function handler(config: Config): Promise<QueryExecutionId[]> {
+export async function handler(): Promise<QueryExecutionId[]> {
+    const config: Config = await getConfig(stage);
     console.log(config)
 
     const StartDate: Moment = moment(config.StartDate);
@@ -32,7 +32,7 @@ export async function handler(config: Config): Promise<QueryExecutionId[]> {
 
     console.log(`Getting total for period ${config.StartDate}-${config.EndDate} with country code ${config.CountryCode} and currency ${config.Currency}`);
 
-    const queries = getQueries(StartDate, EndDate, config.CountryCode, config.Currency, config.Stage, config.CampaignCode);
+    const queries = getQueries(StartDate, EndDate, config.CountryCode, config.Currency, stage, config.CampaignCode);
 
     return executeQueries(queries, config.AthenaOutputBucket, config.SchemaName, athena);
 }

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -23,9 +23,10 @@ class Config {
 
 const stage = process.env.Stage;
 
-export async function handler(): Promise<QueryExecutionId[]> {
-    const config: Config = await getConfig(stage);
-    console.log(config)
+export async function handler(event): Promise<QueryExecutionId[]> {
+    console.log({event})
+    const config: Config = (await getConfig(stage))[event.Name];
+    console.log({config})
 
     const StartDate: Moment = moment(config.StartDate);
     const EndDate: Moment = moment(config.EndDate);

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -25,7 +25,7 @@ class Config {
 // const config = new Config();
 
 export async function handler(config: Config): Promise<QueryExecutionId[]> {
-    console.log(event)
+    console.log(config)
 
     const StartDate: Moment = moment(config.StartDate);
     const EndDate: Moment = moment(config.EndDate);

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -23,10 +23,13 @@ class Config {
 
 const stage = process.env.Stage;
 
-export async function handler(event): Promise<QueryExecutionId[]> {
-    console.log({event})
+interface Event {
+    Name: string;
+}
+
+export async function handler(event: Event): Promise<QueryExecutionId[]> {
+    console.log({event});
     const config: Config = (await getConfig(stage))[event.Name];
-    console.log({config})
 
     const StartDate: Moment = moment(config.StartDate);
     const EndDate: Moment = moment(config.EndDate);

--- a/src/value-ticker/query-lambda/query-lambda.ts
+++ b/src/value-ticker/query-lambda/query-lambda.ts
@@ -22,9 +22,9 @@ class Config {
     SchemaName: string = process.env.SchemaName;
 }
 
-const config = new Config();
+// const config = new Config();
 
-export async function handler(event): Promise<QueryExecutionId[]> {
+export async function handler(config: Config): Promise<QueryExecutionId[]> {
     console.log(event)
 
     const StartDate: Moment = moment(config.StartDate);

--- a/src/value-ticker/riff-raff.yaml
+++ b/src/value-ticker/riff-raff.yaml
@@ -11,3 +11,8 @@ deployments:
       functionNames:
         - contributions-ticker-query-lambda-
         - contributions-ticker-calculate-lambda-
+  contributions-ticker-calculator-cloudformation:
+    type: cloud-formation
+    app: contributions-ticker-calculator
+    parameters:
+      templatePath: cloudformation/cloudformation.yaml

--- a/src/value-ticker/ticker.conf.json
+++ b/src/value-ticker/ticker.conf.json
@@ -1,8 +1,5 @@
 {
   "US_2022": {
-    "Stage": "CODE",
-    "AthenaOutputBucket": "acquisition-events-output",
-    "SchemaName": "acquisition",
     "CountryCode": "US",
     "Currency": "USD",
     "StartDate": "2021-11-22",
@@ -10,13 +7,9 @@
 
     "InitialAmount": 850000,
     "GoalAmount": 1250000,
-    "TickerBucket": "contributions-ticker",
     "OutputFilename": "US_2022.json"
   },
   "AU_2022": {
-    "Stage": "CODE",
-    "AthenaOutputBucket": "acquisition-events-output",
-    "SchemaName": "acquisition",
     "CountryCode": "AU",
     "Currency": "AUD",
     "StartDate": "2021-11-22",
@@ -24,7 +17,6 @@
 
     "InitialAmount": 850000,
     "GoalAmount": 1250000,
-    "TickerBucket": "contributions-ticker",
     "OutputFilename": "AU_2022.json"
   }
 }

--- a/src/value-ticker/ticker.conf.json
+++ b/src/value-ticker/ticker.conf.json
@@ -1,0 +1,30 @@
+{
+  "US_2022": {
+    "Stage": "CODE",
+    "AthenaOutputBucket": "acquisition-events-output",
+    "SchemaName": "acquisition",
+    "CountryCode": "US",
+    "Currency": "USD",
+    "StartDate": "2021-11-22",
+    "EndDate": "2022-01-01",
+
+    "InitialAmount": 850000,
+    "GoalAmount": 1250000,
+    "TickerBucket": "contributions-ticker",
+    "OutputFilename": "US_2022.json"
+  },
+  "AU_2022": {
+    "Stage": "CODE",
+    "AthenaOutputBucket": "acquisition-events-output",
+    "SchemaName": "acquisition",
+    "CountryCode": "AU",
+    "Currency": "AUD",
+    "StartDate": "2021-11-22",
+    "EndDate": "2022-01-01",
+
+    "InitialAmount": 850000,
+    "GoalAmount": 1250000,
+    "TickerBucket": "contributions-ticker",
+    "OutputFilename": "AU_2022.json"
+  }
+}

--- a/src/value-ticker/ticker.conf.json
+++ b/src/value-ticker/ticker.conf.json
@@ -6,8 +6,7 @@
     "EndDate": "2022-01-01",
 
     "InitialAmount": 850000,
-    "GoalAmount": 1250000,
-    "OutputFilename": "US_2022.json"
+    "GoalAmount": 1250000
   },
   "AU_2022": {
     "CountryCode": "AU",
@@ -16,7 +15,6 @@
     "EndDate": "2022-01-01",
 
     "InitialAmount": 850000,
-    "GoalAmount": 1250000,
-    "OutputFilename": "AU_2022.json"
+    "GoalAmount": 1250000
   }
 }


### PR DESCRIPTION
This PR enables the same state machine to run for different ticker campaigns.

1. The state machine now takes a `Name` as an input, to tell it which campaign name to run for (currently US_2022 or AU_2022)
2. There are now two cloudwatch events, one for each campaign name
3. Any cloudformation parameters relating to the ticker config (e.g. startDate, currency) have been removed, and are now loaded from a ticker.conf.json file in S3. This file contains config for each campaign, and there's an example in this PR. The lambdas have to load this config.

This means we now have to maintain ticker settings in an S3 file at: `membership-private/${Stage}/ticker.conf.json`.
And the only part of the repo that is aware of the ticker campaign names is the cloudwatch events in the cloudformation.yaml.