### PR TITLE
Use supporter count query for ticker (for australian banner)

### DIFF
--- a/src/value-ticker/query-lambda/queries.ts
+++ b/src/value-ticker/query-lambda/queries.ts
@@ -50,18 +50,29 @@ const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryC
     'acquisition_events_secondMonthlyQuery'
 );
 
+const supporterCountQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string, campaignCode?: string) => new Query(
+    'SELECT COUNT(*) ' +
+        `FROM ${tableName} ` +
+        `WHERE countryCode = '${countryCode}' ` +
+        `AND currency = '${currency}' ` +
+        (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
+        `AND ${partitionDateField} >= date'${formatDateTime(startDate)}' `,
+    'acquisition_events_full'
+);
+
 /**
  * If a campaign runs for more than a month then double any monthly contributions received before the final month.
  * This logic assumes campaigns will not run for more than 2 months.
  */
 export function getQueries(startDate: Moment, endDate: Moment, countryCode: string, currency: string, stage: string, campaignCode?: string): Query[] {
-    const oneMonthBeforeEnd = endDate.clone().subtract(1, 'month');
+    // const oneMonthBeforeEnd = endDate.clone().subtract(1, 'month');
     const tableName = `acquisition_events_${stage.toLowerCase()}`;
 
-    if (oneMonthBeforeEnd.isAfter(startDate)) return [
-        oneOffAndAnnuallyQuery(startDate, countryCode, currency, tableName, campaignCode),
-        firstMonthlyQuery(startDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode),
-        secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode)
-    ];
-    else return [fullQuery(startDate, countryCode, currency, tableName, campaignCode)];
+    // if (oneMonthBeforeEnd.isAfter(startDate)) return [
+    //     oneOffAndAnnuallyQuery(startDate, countryCode, currency, tableName, campaignCode),
+    //     firstMonthlyQuery(startDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode),
+    //     secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode)
+    // ];
+    // else return [fullQuery(startDate, countryCode, currency, tableName, campaignCode)];
+    return [supporterCountQuery(startDate, countryCode, currency, tableName, campaignCode)]
 }


### PR DESCRIPTION
Trello card: https://trello.com/c/WSEGOVkC/1240-%F0%9F%87%A6%F0%9F%87%BA-australia-banner-alter-tickers-backend

This PR changes the value ticker to use a query that counts the number of supporters (rather than the numeric value of support).

@tomrf1 and I have tested in code that the state machine now reads the correct data when called with the AUS ticker name. We can’t test the ticker in code because SDC always queries the prod S3 files for ticker data. Once this is merged we should be able to see the prod ticker data in code by creating a ticker-containing banner in the code RRCP.