### PR TITLE
Remove _2022 from ticker names

### DIFF
--- a/docs/campaign-setup.md
+++ b/docs/campaign-setup.md
@@ -3,20 +3,20 @@
 ## Creating a new ticker campaign
 
 ### 1. Add a cloudwatch event
-In the [cloudformation.yaml](../src/value-ticker/cloudformation.yaml), add a scheduled event for the new campaign name. E.g. for `US_2022`:
+In the [cloudformation.yaml](../src/value-ticker/cloudformation.yaml), add a scheduled event for the new campaign name. E.g. for `US`:
 
 ```
   ScheduleUS:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub contributions-ticker-calculator-schedule-US_2022-${Stage}
+      Name: !Sub contributions-ticker-calculator-schedule-US-${Stage}
       ScheduleExpression: !Sub cron(${CronExpression})
       State: !Ref ScheduleState
       Targets:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
-          Input: '{ "Name": "US_2022" }'
+          Input: '{ "Name": "US" }'
 ```
 
 This is a code change and requires a riff-raff deploy.

--- a/src/value-ticker/README.md
+++ b/src/value-ticker/README.md
@@ -16,7 +16,7 @@ Events from this stream are processed by the [acquisitions-firehose-transformer]
 
 The calculated ticker value is output to `{bucket}/{STAGE}/{campaign_name}.json`.
 
-This file is cached behind fastly in both CODE and PROD, e.g [https://support.theguardian.com/ticker/US_2022.json](https://support.theguardian.com/ticker/US_2022.json).
+This file is cached behind fastly in both CODE and PROD, e.g [https://support.theguardian.com/ticker/US.json](https://support.theguardian.com/ticker/US.json).
 
 ### Config
 
@@ -32,4 +32,4 @@ Trigger a one-off run from the Step Functions console page (`contributions-ticke
 
 The state machine takes a `Name` parameter, e.g:
 
-`{ "Name": "US_2022" }`
+`{ "Name": "US" }`

--- a/src/value-ticker/cloudformation.yaml
+++ b/src/value-ticker/cloudformation.yaml
@@ -211,25 +211,25 @@ Resources:
   ScheduleUS:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub contributions-ticker-calculator-schedule-US_2022-${Stage}
+      Name: !Sub contributions-ticker-calculator-schedule-US-${Stage}
       ScheduleExpression: !Sub cron(${CronExpression})
       State: !Ref ScheduleState
       Targets:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
-          Input: '{ "Name": "US_2022" }'
+          Input: '{ "Name": "US" }'
   ScheduleAU:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub contributions-ticker-calculator-schedule-AU_2022-${Stage}
+      Name: !Sub contributions-ticker-calculator-schedule-AU-${Stage}
       ScheduleExpression: !Sub cron(${CronExpression})
       State: !Ref ScheduleState
       Targets:
         - Arn: !Ref StateMachine
           RoleArn: !GetAtt TriggerExecutionRole.Arn
           Id: !GetAtt StateMachine.Name
-          Input: '{ "Name": "AU_2022" }'
+          Input: '{ "Name": "AU" }'
 
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/src/value-ticker/query-lambda/local.ts
+++ b/src/value-ticker/query-lambda/local.ts
@@ -13,7 +13,7 @@ AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
 async function run() {
-    await handler({ Name: 'US_2022' })
+    await handler({ Name: 'US' })
         .then(result => console.log(`Result: ${JSON.stringify(result)}`))
         .catch(err => console.log(`Error: ${err}`))
 }

--- a/src/value-ticker/ticker.conf.json
+++ b/src/value-ticker/ticker.conf.json
@@ -1,5 +1,5 @@
 {
-  "US_2022": {
+  "US": {
     "CountryCode": "US",
     "Currency": "USD",
     "StartDate": "2021-11-22",
@@ -8,7 +8,7 @@
     "InitialAmount": 850000,
     "GoalAmount": 1250000
   },
-  "AU_2022": {
+  "AU": {
     "CountryCode": "AU",
     "Currency": "AUD",
     "StartDate": "2021-11-22",


### PR DESCRIPTION
Since we’re re-using the ticker from last year, it seems sensible to remove the year from the name. Adding a new ticker each year doesn’t seem like the right way to go about things. This PR will need to be co-ordinated with the similar ones on support-dotcom-components and support-admin-console.