### PR TITLE
Remove currency from the supporterCountQuery

### DIFF
--- a/src/value-ticker/query-lambda/queries.ts
+++ b/src/value-ticker/query-lambda/queries.ts
@@ -50,11 +50,10 @@ const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryC
     'acquisition_events_secondMonthlyQuery'
 );
 
-const supporterCountQuery = (startDate: Moment, countryCode: string, currency: string, tableName: string, campaignCode?: string) => new Query(
+const supporterCountQuery = (startDate: Moment, countryCode: string, tableName: string, campaignCode?: string) => new Query(
     'SELECT COUNT(*) ' +
         `FROM ${tableName} ` +
         `WHERE countryCode = '${countryCode}' ` +
-        `AND currency = '${currency}' ` +
         (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
         `AND ${partitionDateField} >= date'${formatDateTime(startDate)}' `,
     'acquisition_events_full'
@@ -74,5 +73,5 @@ export function getQueries(startDate: Moment, endDate: Moment, countryCode: stri
     //     secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode)
     // ];
     // else return [fullQuery(startDate, countryCode, currency, tableName, campaignCode)];
-    return [supporterCountQuery(startDate, countryCode, currency, tableName, campaignCode)]
+    return [supporterCountQuery(startDate, countryCode, tableName, campaignCode)]
 }


### PR DESCRIPTION
## What does this change?

This PR removes the currency filter from the `supporterCountQuery`. A currency filter is required for the other queries as they return monetary values, and we shouldn’t be mixing currencies on queries used to display monetary values, however it is not needed for a “supporter count” ticker. The stakeholder pointed this out and made the request.

[Trello](https://trello.com/c/YdwCMkXN/1313-server-side-updates-for-aus-10-year-anniversary-moments-ticker)