### PR TITLE
Riff Raff: Add cloudformation dependency to lambda build

### DIFF
--- a/src/value-ticker/riff-raff.yaml
+++ b/src/value-ticker/riff-raff.yaml
@@ -6,6 +6,8 @@ allowedStages:
 deployments:
   contributions-ticker-calculator:
     type: aws-lambda
+    dependencies:
+      - contributions-ticker-calculator-cloudformation
     parameters:
       prefixStack: false
       bucket: membership-dist


### PR DESCRIPTION
The lambda build step should have a dependency on the cloudformation step, so that they don’t conflict. This is described [in the Riff Raff documentation](https://riffraff.gutools.co.uk/docs/reference/riff-raff.yaml.md).