### PR TITLE
Update to actions/setup-node@v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Show env (helpful for debugging)
         run: env
       - name: Setup Node
-        uses: guardian/actions-setup-node@v2.4.1
+        uses: actions/setup-node@v3
         with:
           cache: "yarn"
           cache-dependency-path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
+          node-version-file: '.nvmrc'
           cache: "yarn"
           cache-dependency-path: |
             src/value-ticker/yarn.lock
-          node-version: 18.x
       - name: Copy libs
         # So that we can share the code in lib between sub-projects.
         # TODO - can we do better than this? Does yarn workspaces help?


### PR DESCRIPTION
## What are you doing in this PR?

Github Actions: Stop using guardian/actions-setup-node and use actions/setup-node instead

[**Trello Card**](https://trello.com/c/dlZA1kOt/1546-github-actions-stop-using-guardian-actions-setup-node-and-use-actions-setup-node-instead)

## Why are you doing this?

The [actions-setup-node repo ] (https://github.com/guardian/actions-setup-node) says that  has been archived by the owner on Dec 5, 2022 and will not be updated.

The official Github [actions/setup-node](https://github.com/marketplace/actions/setup-node-js-environment) now has [some support for node version files](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file).

You should use that instead.