### PR TITLE
US Ticker backend changes

### DIFF
--- a/src/value-ticker/query-lambda/queries.ts
+++ b/src/value-ticker/query-lambda/queries.ts
@@ -50,28 +50,28 @@ const secondMonthlyQuery = (endDate: Moment, oneMonthBeforeEnd: Moment, countryC
     'acquisition_events_secondMonthlyQuery'
 );
 
-const supporterCountQuery = (startDate: Moment, countryCode: string, tableName: string, campaignCode?: string) => new Query(
-    'SELECT COUNT(*) ' +
-        `FROM ${tableName} ` +
-        `WHERE countryCode = '${countryCode}' ` +
-        (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
-        `AND ${partitionDateField} >= date'${formatDateTime(startDate)}' `,
-    'acquisition_events_full'
-);
+// const supporterCountQuery = (startDate: Moment, countryCode: string, tableName: string, campaignCode?: string) => new Query(
+//     'SELECT COUNT(*) ' +
+//         `FROM ${tableName} ` +
+//         `WHERE countryCode = '${countryCode}' ` +
+//         (campaignCode ? `AND campaignCode = '${campaignCode}' ` : '') +
+//         `AND ${partitionDateField} >= date'${formatDateTime(startDate)}' `,
+//     'acquisition_events_full'
+// );
 
 /**
  * If a campaign runs for more than a month then double any monthly contributions received before the final month.
  * This logic assumes campaigns will not run for more than 2 months.
  */
 export function getQueries(startDate: Moment, endDate: Moment, countryCode: string, currency: string, stage: string, campaignCode?: string): Query[] {
-    // const oneMonthBeforeEnd = endDate.clone().subtract(1, 'month');
+    const oneMonthBeforeEnd = endDate.clone().subtract(1, 'month');
     const tableName = `acquisition_events_${stage.toLowerCase()}`;
 
-    // if (oneMonthBeforeEnd.isAfter(startDate)) return [
-    //     oneOffAndAnnuallyQuery(startDate, countryCode, currency, tableName, campaignCode),
-    //     firstMonthlyQuery(startDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode),
-    //     secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode)
-    // ];
-    // else return [fullQuery(startDate, countryCode, currency, tableName, campaignCode)];
-    return [supporterCountQuery(startDate, countryCode, tableName, campaignCode)]
+    if (oneMonthBeforeEnd.isAfter(startDate)) return [
+        oneOffAndAnnuallyQuery(startDate, countryCode, currency, tableName, campaignCode),
+        firstMonthlyQuery(startDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode),
+        secondMonthlyQuery(endDate, oneMonthBeforeEnd, countryCode, currency, tableName, campaignCode)
+    ];
+    else return [fullQuery(startDate, countryCode, currency, tableName, campaignCode)];
+    // return [supporterCountQuery(startDate, countryCode, tableName, campaignCode)]
 }


### PR DESCRIPTION
## What does this change?

US Ticker backend changes to reflect an amounts target(value of the support) instead of the supporter count ( the number of supporters ). The new total is: $1.5m

Trello card [Here](https://trello.com/c/M8O4Tc2Q/1599-us-ticker-backend-changes)


Tested the change  in CODE .

 Instead of showing the supporter count , the US.json in the https://s3.console.aws.amazon.com/s3/object/contributions-ticker?region=eu-west-1&prefix=$STAGE/US.json file  would show the amounts targets (Replace the STAGE value  in the above) 


This change would be updated for AUS as well ,but the final target has not been confirmed yet for Australia.

Also we need to modify the  ticker.conf.json in membership-private for PROD  to below

<img width="408" alt="image" src="https://github.com/guardian/contributions-ticker-calculator/assets/73653255/17b13d05-e01b-469e-82b6-75987a85524d">


Reference PR: https://github.com/guardian/contributions-ticker-calculator/pull/52