### PR TITLE
Prevent null values when no data

### DIFF
--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -74,7 +74,7 @@ export const runQuery = async (
             AND transaction_currency = '${config.Currency}'
             AND country_code = '${config.CountryCode}'
         )
-        SELECT SUM(amount) AS amount FROM (
+        SELECT COALESCE(SUM(amount), 0) AS amount FROM (
             SELECT amount FROM contributions__once UNION ALL
             SELECT amount FROM contributions__twice UNION ALL
             SELECT amount FROM supporter_plus_or_tier_three__once UNION ALL


### PR DESCRIPTION
If there's no data yet (because the campaign hasn't started) then bigquery returns `null`.
This PR uses [COALESCE](https://cloud.google.com/bigquery/docs/reference/standard-sql/conditional_expressions#coalesce) to return 0 in this case