### PR TITLE
AUS ticker for Nov 2024 Campaign

### DIFF
--- a/cdk/lib/__snapshots__/ticker-calculator.test.ts.snap
+++ b/cdk/lib/__snapshots__/ticker-calculator.test.ts.snap
@@ -115,6 +115,45 @@ exports[`The TickerCalculator stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
+    "TickerCalculatorTickerCalculatorrate15minutes161311C65": {
+      "Properties": {
+        "Description": "AU",
+        "ScheduleExpression": "rate(15 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "TickerCalculator5AB41211",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": ""AU"",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "TickerCalculatorTickerCalculatorrate15minutes1AllowEventRuleTickerCalculator3A61D8F5E506B789": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "TickerCalculator5AB41211",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "TickerCalculatorTickerCalculatorrate15minutes161311C65",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "querylambdaroleC6C8A94B": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/cdk/lib/ticker-calculator.ts
+++ b/cdk/lib/ticker-calculator.ts
@@ -21,6 +21,11 @@ export class TickerCalculator extends GuStack {
 				description: 'US',
 				input: RuleTargetInput.fromText('US'),
 			},
+			{
+				schedule: Schedule.rate(Duration.minutes(15)),
+				description: 'AU',
+				input: RuleTargetInput.fromText('AU'),
+			},
 		];
 
 		const role = new Role(this, 'query-lambda-role', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a new schedule for AU to support the AUS  Nov Campaign on all major assets, their target will be $400,000 AUS dollars with a $20,000 headstart 

The AU ticker query should also include the  IAP acquisitions