### PR TITLE
Global supporter count ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ticker-calculator
 
-Counts money during a campaign and outputs to an S3 file. Used by epic/banner/thrashers and the support site landing page.
+Counts money or acquisitions during a campaign and outputs to an S3 file. Used by epic/banner/thrashers and the support site landing page.
 
 The calculated ticker value is output to the bucket `contributions-ticker`, with key `{STAGE}/{campaign_name}.json`.
 
@@ -14,13 +14,21 @@ The stack defines a cloudwatch event for each campaign. The event is scheduled f
 
 The ticker config is loaded by the lambda from Parameter Store (key: `/ticker-calculator/{STAGE}/ticker-config`). This file contains config for each campaign [./src/ticker.conf.json](see example).
 
+There are two types of ticker config:
+1. Money
+2. SupporterCount
+
 ### Data
 
+#### Ticker type `Money`
 The lambda queries two tables:
 1. `fact_aquisition_event` for contributions. This table has live acquisitions data, and so contributions will be added to the ticker throughout the day.
 2. `fact_holding_acquisition` for SupporterPlus and ThreeTier. This table is only updated daily, so these acquisitions will only be added to the ticker once a day. This is because the `amount` isn't available in the live `fact_aquisition_event` table.
 
 We also count acquisitions twice if the billing period is monthly and two payments will be made during the campaign. This assumes no campaign runs for more than 2 months.
+
+#### Ticker type `SupporterCount`
+The lambda queries the `fact_aquisition_event` for single/recurring contributions, SupporterPlus and TierThree. This data is live.
 
 ### Testing
 

--- a/cdk/lib/__snapshots__/ticker-calculator.test.ts.snap
+++ b/cdk/lib/__snapshots__/ticker-calculator.test.ts.snap
@@ -154,6 +154,45 @@ exports[`The TickerCalculator stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
+    "TickerCalculatorTickerCalculatorrate15minutes2AllowEventRuleTickerCalculator3A61D8F5B129E114": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "TickerCalculator5AB41211",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "TickerCalculatorTickerCalculatorrate15minutes2F658BDF5",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "TickerCalculatorTickerCalculatorrate15minutes2F658BDF5": {
+      "Properties": {
+        "Description": "global",
+        "ScheduleExpression": "rate(15 minutes)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "TickerCalculator5AB41211",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": ""global"",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "querylambdaroleC6C8A94B": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/cdk/lib/ticker-calculator.ts
+++ b/cdk/lib/ticker-calculator.ts
@@ -26,6 +26,11 @@ export class TickerCalculator extends GuStack {
 				description: 'AU',
 				input: RuleTargetInput.fromText('AU'),
 			},
+			{
+				schedule: Schedule.rate(Duration.minutes(15)),
+				description: 'global',
+				input: RuleTargetInput.fromText('global'),
+			},
 		];
 
 		const role = new Role(this, 'query-lambda-role', {

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,39 +1,41 @@
-import {buildAuthClient, runQuery} from './lib/bigquery';
-import type {TickerConfig, TickerResult} from './lib/models';
-import { writeToS3 } from "./lib/s3";
+import { buildAuthClient, runQuery } from './lib/bigquery';
+import type { TickerConfig, TickerResult } from './lib/models';
+import { writeToS3 } from './lib/s3';
 import { getSSMParam } from './lib/ssm';
 
 const TickerBucket = 'contributions-ticker';
 
 export async function handler(campaignName: string): Promise<void> {
-    console.log('campaignName: ', campaignName);
-    const stage = process.env.Stage;
-    if (!stage || (stage !== 'CODE' && stage !== 'PROD')) {
-        return Promise.reject(`Invalid or missing stage: '${stage ?? ''}'`);
-    }
+	console.log('campaignName: ', campaignName);
+	const stage = process.env.Stage;
+	if (!stage || (stage !== 'CODE' && stage !== 'PROD')) {
+		return Promise.reject(`Invalid or missing stage: '${stage ?? ''}'`);
+	}
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- config
-    const tickerConfig: Record<string,TickerConfig> = JSON.parse(await getSSMParam('ticker-config', stage));
-    const gcpConfig = await getSSMParam('gcp-wif-credentials-config', stage);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- config
+	const tickerConfig: Record<string, TickerConfig> = JSON.parse(
+		await getSSMParam('ticker-config', stage),
+	);
+	const gcpConfig = await getSSMParam('gcp-wif-credentials-config', stage);
 
-    const campaignConfig = tickerConfig[campaignName];
-    console.log('Using config:', campaignConfig);
+	const campaignConfig = tickerConfig[campaignName];
+	console.log('Using config:', campaignConfig);
 
-    const authClient = await buildAuthClient(gcpConfig);
+	const authClient = await buildAuthClient(gcpConfig);
 
-    const amount = await runQuery(authClient, stage, campaignConfig);
+	const amount = await runQuery(authClient, stage, campaignConfig);
 
-    const result: TickerResult = {
-        goal: campaignConfig.GoalAmount,
-        total: Math.round(amount) + campaignConfig.InitialAmount,
-        type: campaignConfig.type,
-    }
-    console.log('Writing result to S3:', result);
+	const result: TickerResult = {
+		goal: campaignConfig.GoalAmount,
+		total: Math.round(amount) + campaignConfig.InitialAmount,
+		type: campaignConfig.type,
+	};
+	console.log('Writing result to S3:', result);
 
-    const s3Result = await writeToS3({
-        data: result,
-        bucket: TickerBucket,
-        key: `${stage}/${campaignName}.json`,
-    })
-    console.log('Result from S3: ', s3Result);
+	const s3Result = await writeToS3({
+		data: result,
+		bucket: TickerBucket,
+		key: `${stage}/${campaignName}.json`,
+	});
+	console.log('Result from S3: ', s3Result);
 }

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -26,6 +26,7 @@ export async function handler(campaignName: string): Promise<void> {
     const result: TickerResult = {
         goal: campaignConfig.GoalAmount,
         total: Math.round(amount) + campaignConfig.InitialAmount,
+        type: campaignConfig.type,
     }
     console.log('Writing result to S3:', result);
 

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,4 +1,4 @@
-import { buildAuthClient, runQuery } from './lib/bigquery';
+import {buildAuthClient, runQuery} from './lib/bigquery';
 import type {TickerConfig, TickerResult} from './lib/models';
 import { writeToS3 } from "./lib/s3";
 import { getSSMParam } from './lib/ssm';
@@ -20,6 +20,7 @@ export async function handler(campaignName: string): Promise<void> {
     console.log('Using config:', campaignConfig);
 
     const authClient = await buildAuthClient(gcpConfig);
+
     const amount = await runQuery(authClient, stage, campaignConfig);
 
     const result: TickerResult = {

--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -107,7 +107,7 @@ const buildSupporterCountQuery =(
         FROM datalake.fact_acquisition_event
         WHERE event_timestamp >= '${config.StartDate}' AND event_timestamp < '${config.EndDate}'
         AND product IN ('CONTRIBUTION', 'RECURRING_CONTRIBUTION', 'SUPPORTER_PLUS', 'TIER_THREE')
-        AND country_code NOT IN '(${config.ExcludedCountryCodes.join(',')})'
+        AND country_code NOT IN (${config.ExcludedCountryCodes.map(c => `'${c}'`).join(',')})
     `;
 }
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -23,6 +23,7 @@ type TickerConfig = MoneyTickerConfig | SupporterCountTickerConfig;
 interface TickerResult {
     total: number;
     goal: number;
+    type: TickerConfig['type'];
 }
 
 export {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,4 +1,5 @@
-interface TickerConfig {
+interface MoneyTickerConfig {
+    type: 'Money';
     StartDate: string;
     EndDate: string;
     CountryCode: string;
@@ -8,6 +9,17 @@ interface TickerConfig {
     GoalAmount: number;
 }
 
+interface SupporterCountTickerConfig {
+    type: 'SupporterCount';
+    StartDate: string;
+    EndDate: string;
+    ExcludedCountryCodes: string[];
+    InitialAmount: number;
+    GoalAmount: number;
+}
+
+type TickerConfig = MoneyTickerConfig | SupporterCountTickerConfig;
+
 interface TickerResult {
     total: number;
     goal: number;
@@ -16,4 +28,6 @@ interface TickerResult {
 export {
     TickerConfig,
     TickerResult,
+    MoneyTickerConfig,
+    SupporterCountTickerConfig,
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,34 +1,34 @@
 interface MoneyTickerConfig {
-    type: 'Money';
-    StartDate: string;
-    EndDate: string;
-    CountryCode: string;
-    Currency: string;
-    CampaignCode?: string;
-    InitialAmount: number;
-    GoalAmount: number;
+	type: 'Money';
+	StartDate: string;
+	EndDate: string;
+	CountryCode: string;
+	Currency: string;
+	CampaignCode?: string;
+	InitialAmount: number;
+	GoalAmount: number;
 }
 
 interface SupporterCountTickerConfig {
-    type: 'SupporterCount';
-    StartDate: string;
-    EndDate: string;
-    ExcludedCountryCodes: string[];
-    InitialAmount: number;
-    GoalAmount: number;
+	type: 'SupporterCount';
+	StartDate: string;
+	EndDate: string;
+	ExcludedCountryCodes: string[];
+	InitialAmount: number;
+	GoalAmount: number;
 }
 
 type TickerConfig = MoneyTickerConfig | SupporterCountTickerConfig;
 
 interface TickerResult {
-    total: number;
-    goal: number;
-    type: TickerConfig['type'];
+	total: number;
+	goal: number;
+	type: TickerConfig['type'];
 }
 
 export {
-    TickerConfig,
-    TickerResult,
-    MoneyTickerConfig,
-    SupporterCountTickerConfig,
-}
+	TickerConfig,
+	TickerResult,
+	MoneyTickerConfig,
+	SupporterCountTickerConfig,
+};

--- a/src/ticker.conf.json
+++ b/src/ticker.conf.json
@@ -1,5 +1,6 @@
 {
   "US": {
+    "type": "Money",
     "CountryCode": "US",
     "Currency": "USD",
     "StartDate": "2021-11-22",
@@ -9,6 +10,7 @@
     "GoalAmount": 1250000
   },
   "AU": {
+    "type": "Money",
     "CountryCode": "AU",
     "Currency": "AUD",
     "StartDate": "2021-11-22",
@@ -16,5 +18,14 @@
 
     "InitialAmount": 850000,
     "GoalAmount": 1250000
+  },
+  "global": {
+    "type": "SupporterCount",
+    "StartDate": "2025-04-30",
+    "EndDate": "2025-05-23",
+    "ExcludedCountryCodes": ["AU"],
+
+    "InitialAmount": 0,
+    "GoalAmount": 50000
   }
 }


### PR DESCRIPTION
This PR adds support for a new type of ticker that counts the number of supporters, rather than the amount of money.
This is for an upcoming campaign that will count acquisitions from all users globally, excluding AU.

The config in parameter store will need to include a new item for a `global` campaign:
```
"global": {
  "type": "SupporterCount",
  "StartDate": "2025-04-30",
  "EndDate": "2025-05-23",
  "ExcludedCountryCodes": ["AU"],

  "InitialAmount": 0,
  "GoalAmount": 50000
}
```

We'll also need to update support-admin-console + support-dotcom-components to support the new `global` ticker campaign. Currently they only allow `US` or `AU`.

Tested in CODE by running the lambda and checking for the new output file:
```
$ curl https://support.code.dev-theguardian.com/ticker/global.json
{"goal":50000,"total":37,"type":"SupporterCount"}
```