### PR TITLE
Remove exclusions from global count

### DIFF
--- a/src/lib/bigquery.ts
+++ b/src/lib/bigquery.ts
@@ -147,9 +147,6 @@ const buildSupporterCountQuery = (
 		config.EndDate
 	}'
         AND product IN ('CONTRIBUTION', 'RECURRING_CONTRIBUTION', 'SUPPORTER_PLUS', 'TIER_THREE')
-        AND country_code NOT IN (${config.ExcludedCountryCodes.map(
-					(c) => `'${c}'`,
-				).join(',')})
     `;
 };
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -13,7 +13,6 @@ interface SupporterCountTickerConfig {
 	type: 'SupporterCount';
 	StartDate: string;
 	EndDate: string;
-	ExcludedCountryCodes: string[];
 	InitialAmount: number;
 	GoalAmount: number;
 }

--- a/src/ticker.conf.json
+++ b/src/ticker.conf.json
@@ -23,7 +23,6 @@
     "type": "SupporterCount",
     "StartDate": "2025-04-30",
     "EndDate": "2025-05-23",
-    "ExcludedCountryCodes": ["AU"],
 
     "InitialAmount": 0,
     "GoalAmount": 50000


### PR DESCRIPTION
this feature is no longer required, and setting `"ExcludedCountryCodes": []` causes it to build an invalid sql query

Test run in CODE:
<img width="652" alt="Screenshot 2025-04-30 at 09 29 58" src="https://github.com/user-attachments/assets/7b265f8d-97cb-4dce-a240-f61504668d2f" />
