### PR TITLE
Resolve critical and high security vulnerabilities: handlebars, flatted, and picomatch

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,83 +1,86 @@
 {
-  "name": "cdk",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "build": "tsc",
-    "test": "jest",
-    "test-update": "jest -u",
-    "format": "prettier --write \"{lib,bin}/**/*.ts\"",
-    "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
-    "synth": "cdk synth --path-metadata false --version-reporting false",
-    "diff": "cdk diff --path-metadata false --version-reporting false"
-  },
-  "devDependencies": {
-    "@guardian/cdk": "61.1.3",
-    "@guardian/eslint-config-typescript": "8.0.0",
-    "@guardian/prettier": "5.0.0",
-    "@guardian/tsconfig": "^1.0.0",
-    "@types/jest": "^29.5.12",
-    "@types/node": "^22.0.0",
-    "aws-cdk": "2.177.0",
-    "aws-cdk-lib": "2.177.0",
-    "constructs": "10.3.0",
-    "eslint": "^8.57.0",
-    "jest": "^29.7.0",
-    "prettier": "^3.3.3",
-    "source-map-support": "^0.5.20",
-    "ts-jest": "^29.2.5",
-    "ts-node": "^10.9.2",
-    "typescript": "5.1.6"
-  },
-  	"resolutions": {
-		"**/minimatch@>=3.1.1 <3.1.4": "3.1.4",
-		"**/minimatch@>=9.0.0 <9.0.7": "9.0.7"
+	"name": "cdk",
+	"version": "0.0.0",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"test": "jest",
+		"test-update": "jest -u",
+		"format": "prettier --write \"{lib,bin}/**/*.ts\"",
+		"lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
+		"synth": "cdk synth --path-metadata false --version-reporting false",
+		"diff": "cdk diff --path-metadata false --version-reporting false"
 	},
-  "prettier": "@guardian/prettier",
-  "jest": {
-    "testMatch": [
-      "<rootDir>/lib/**/*.test.ts"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": [
-        "ts-jest",
-        {
-          "useESM": false,
-          "tsconfig": "tsconfig.json"
-        }
-      ]
-    },
-    "setupFilesAfterEnv": [
-      "./jest.setup.js"
-    ]
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true,
-      "jest": true
-    },
-    "extends": [
-      "@guardian/eslint-config-typescript"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/no-inferrable-types": 0,
-      "import/no-namespace": 2
-    },
-    "ignorePatterns": [
-      "**/*.js",
-      "node_modules",
-      "cdk.out",
-      ".eslintrc.js",
-      "jest.config.js"
-    ]
-  },
-  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
+	"devDependencies": {
+		"@guardian/cdk": "61.1.3",
+		"@guardian/eslint-config-typescript": "8.0.0",
+		"@guardian/prettier": "5.0.0",
+		"@guardian/tsconfig": "^1.0.0",
+		"@types/jest": "^29.5.12",
+		"@types/node": "^22.0.0",
+		"aws-cdk": "2.177.0",
+		"aws-cdk-lib": "2.177.0",
+		"constructs": "10.3.0",
+		"eslint": "^8.57.0",
+		"jest": "^29.7.0",
+		"prettier": "^3.3.3",
+		"source-map-support": "^0.5.20",
+		"ts-jest": "^29.2.5",
+		"ts-node": "^10.9.2",
+		"typescript": "5.1.6"
+	},
+	"resolutions": {
+		"**/minimatch@>=3.1.1 <3.1.4": "3.1.4",
+		"**/minimatch@>=9.0.0 <9.0.7": "9.0.7",
+		"handlebars": "4.7.9",
+		"flatted": "3.4.2",
+		"picomatch": "2.3.2"
+	},
+	"prettier": "@guardian/prettier",
+	"jest": {
+		"testMatch": [
+			"<rootDir>/lib/**/*.test.ts"
+		],
+		"transform": {
+			"^.+\\.tsx?$": [
+				"ts-jest",
+				{
+					"useESM": false,
+					"tsconfig": "tsconfig.json"
+				}
+			]
+		},
+		"setupFilesAfterEnv": [
+			"./jest.setup.js"
+		]
+	},
+	"eslintConfig": {
+		"root": true,
+		"env": {
+			"node": true,
+			"jest": true
+		},
+		"extends": [
+			"@guardian/eslint-config-typescript"
+		],
+		"parserOptions": {
+			"ecmaVersion": 2020,
+			"sourceType": "module"
+		},
+		"plugins": [
+			"@typescript-eslint"
+		],
+		"rules": {
+			"@typescript-eslint/no-inferrable-types": 0,
+			"import/no-namespace": 2
+		},
+		"ignorePatterns": [
+			"**/*.js",
+			"node_modules",
+			"cdk.out",
+			".eslintrc.js",
+			"jest.config.js"
+		]
+	},
+	"packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2115,10 +2115,10 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flatted@^3.2.9:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.1.tgz#84ccd9579e76e9cc0d246c11d8be0beb019143e6"
-  integrity sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==
+flatted@3.4.2, flatted@^3.2.9:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -2330,10 +2330,10 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-handlebars@^4.7.8:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@4.7.9, handlebars@^4.7.8:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"
@@ -3648,10 +3648,10 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pirates@^4.0.4:
   version "4.0.7"


### PR DESCRIPTION
Fixes critical Handlebars.js JavaScript injection vulnerability and high-severity flatted/picomatch vulnerabilities by adding package resolutions.

**Security Fixes:**
- Handlebars: 4.7.8 → 4.7.9 (critical JavaScript injection via AST Type Confusion)
- flatted: 3.4.1 → 3.4.2 (prototype pollution via parse())  
- picomatch: 2.3.1 → 2.3.2 (ReDoS vulnerability via extglob quantifiers)

Adds resolutions in package.json to force secure versions across all transitive dependencies.